### PR TITLE
Add ECCV'24 papers

### DIFF
--- a/_data/sources.yaml
+++ b/_data/sources.yaml
@@ -6,8 +6,6 @@
   publisher: "18th European Conference on Computer Vision (ECCV 2024), Milano, Italy, Oct 2024"
 - id: arxiv:2306.11800 # dynaquant
   image: https://ameya.info/images/project-list-thumbnails/dynaquant.png
-- id: arxiv:2306.11800 # dynaquant
-  image: https://ameya.info/images/project-list-thumbnails/dynaquant.png
 - id: arxiv:2407.07000 # metron
   image: https://github.com/project-metron/metron/blob/main/docs/_static/assets/deadline.png?raw=true
   buttons:


### PR DESCRIPTION
This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
